### PR TITLE
Full screen button issue

### DIFF
--- a/src/Components/FullscreenButton.test.tsx
+++ b/src/Components/FullscreenButton.test.tsx
@@ -15,6 +15,10 @@ beforeEach(() => {
     configurable: true,
     value: jest.fn(),
   });
+  Object.defineProperty(document, "fullscreenEnabled", {
+    configurable: true,
+    value: undefined,
+  });
 
   mockedUseFullscreen.mockReturnValue({
     ref: jest.fn(),
@@ -54,6 +58,20 @@ test("calls toggle when fullscreen is supported", () => {
   Object.defineProperty(document, "fullscreenEnabled", {
     configurable: true,
     value: true,
+  });
+
+  renderButton();
+
+  fireEvent.click(screen.getByLabelText("Toggle Fullscreen"));
+  expect(toggle).toHaveBeenCalledTimes(1);
+});
+
+test("treats requestFullscreen as supported when fullscreenEnabled is unavailable", () => {
+  const toggle = jest.fn();
+  mockedUseFullscreen.mockReturnValue({
+    ref: jest.fn(),
+    toggle,
+    fullscreen: false,
   });
 
   renderButton();

--- a/src/Components/FullscreenButton.tsx
+++ b/src/Components/FullscreenButton.tsx
@@ -10,19 +10,29 @@ const isFullscreenSupported = (): boolean => {
 
   const fullscreenDocument = document as Document & {
     webkitFullscreenEnabled?: boolean;
+    mozFullScreenEnabled?: boolean;
+    msFullscreenEnabled?: boolean;
   };
   const fullscreenElement = document.documentElement as HTMLElement & {
     webkitRequestFullscreen?: () => Promise<void>;
+    mozRequestFullScreen?: () => Promise<void>;
+    msRequestFullscreen?: () => Promise<void>;
   };
 
   const canRequestFullscreen = Boolean(
-    fullscreenElement.requestFullscreen || fullscreenElement.webkitRequestFullscreen
+    fullscreenElement.requestFullscreen ||
+      fullscreenElement.webkitRequestFullscreen ||
+      fullscreenElement.mozRequestFullScreen ||
+      fullscreenElement.msRequestFullscreen
   );
+  const fullscreenEnabled =
+    document.fullscreenEnabled ??
+    fullscreenDocument.webkitFullscreenEnabled ??
+    fullscreenDocument.mozFullScreenEnabled ??
+    fullscreenDocument.msFullscreenEnabled;
 
-  return (
-    canRequestFullscreen &&
-    Boolean(document.fullscreenEnabled || fullscreenDocument.webkitFullscreenEnabled)
-  );
+  // Some browsers expose the request API but omit the enabled flag entirely.
+  return canRequestFullscreen && fullscreenEnabled !== false;
 };
 
 export default function FullscreenButton() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix fullscreen button support detection to enable it in more browsers.

The button was incorrectly disabled in browsers that expose `requestFullscreen` but omit `document.fullscreenEnabled` or its vendor-prefixed equivalents. The fix relaxes detection to enable the button if `requestFullscreen` is available, adding fallbacks for vendor-prefixed `fullscreenEnabled` properties.

---
<p><a href="https://cursor.com/agents/bc-65b2199c-f686-46a9-9a97-201b1064e8ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65b2199c-f686-46a9-9a97-201b1064e8ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->