### PR TITLE
Full screen button disabled

### DIFF
--- a/src/Components/FullscreenButton.test.tsx
+++ b/src/Components/FullscreenButton.test.tsx
@@ -34,7 +34,7 @@ const renderButton = () =>
     </MantineProvider>
   );
 
-test("disables fullscreen button when API is unsupported", () => {
+test("does not render fullscreen button when fullscreen is unsupported", () => {
   Object.defineProperty(document, "fullscreenEnabled", {
     configurable: true,
     value: false,
@@ -42,9 +42,7 @@ test("disables fullscreen button when API is unsupported", () => {
 
   renderButton();
 
-  expect(
-    screen.getByLabelText("Fullscreen is not supported on this device/browser")
-  ).toBeDisabled();
+  expect(screen.queryByLabelText("Toggle Fullscreen")).not.toBeInTheDocument();
 });
 
 test("calls toggle when fullscreen is supported", () => {
@@ -78,6 +76,17 @@ test("treats requestFullscreen as supported when fullscreenEnabled is unavailabl
 
   fireEvent.click(screen.getByLabelText("Toggle Fullscreen"));
   expect(toggle).toHaveBeenCalledTimes(1);
+});
+
+test("does not render fullscreen button when request API is unavailable", () => {
+  Object.defineProperty(document.documentElement, "requestFullscreen", {
+    configurable: true,
+    value: undefined,
+  });
+
+  renderButton();
+
+  expect(screen.queryByLabelText("Toggle Fullscreen")).not.toBeInTheDocument();
 });
 
 test("shows failure state when fullscreen request throws", async () => {

--- a/src/Components/FullscreenButton.test.tsx
+++ b/src/Components/FullscreenButton.test.tsx
@@ -34,7 +34,14 @@ const renderButton = () =>
     </MantineProvider>
   );
 
-test("does not render fullscreen button when fullscreen is unsupported", () => {
+test("renders fullscreen button when requestFullscreen exists even if fullscreenEnabled is false", () => {
+  const toggle = jest.fn();
+  mockedUseFullscreen.mockReturnValue({
+    ref: jest.fn(),
+    toggle,
+    fullscreen: false,
+  });
+
   Object.defineProperty(document, "fullscreenEnabled", {
     configurable: true,
     value: false,
@@ -42,7 +49,8 @@ test("does not render fullscreen button when fullscreen is unsupported", () => {
 
   renderButton();
 
-  expect(screen.queryByLabelText("Toggle Fullscreen")).not.toBeInTheDocument();
+  fireEvent.click(screen.getByLabelText("Toggle Fullscreen"));
+  expect(toggle).toHaveBeenCalledTimes(1);
 });
 
 test("calls toggle when fullscreen is supported", () => {
@@ -78,8 +86,43 @@ test("treats requestFullscreen as supported when fullscreenEnabled is unavailabl
   expect(toggle).toHaveBeenCalledTimes(1);
 });
 
+test("renders fullscreen button when only webkitRequestFullscreen exists", () => {
+  const toggle = jest.fn();
+  mockedUseFullscreen.mockReturnValue({
+    ref: jest.fn(),
+    toggle,
+    fullscreen: false,
+  });
+
+  Object.defineProperty(document.documentElement, "requestFullscreen", {
+    configurable: true,
+    value: undefined,
+  });
+  Object.defineProperty(document.documentElement, "webkitRequestFullscreen", {
+    configurable: true,
+    value: jest.fn(),
+  });
+
+  renderButton();
+
+  fireEvent.click(screen.getByLabelText("Toggle Fullscreen"));
+  expect(toggle).toHaveBeenCalledTimes(1);
+});
+
 test("does not render fullscreen button when request API is unavailable", () => {
   Object.defineProperty(document.documentElement, "requestFullscreen", {
+    configurable: true,
+    value: undefined,
+  });
+  Object.defineProperty(document.documentElement, "webkitRequestFullscreen", {
+    configurable: true,
+    value: undefined,
+  });
+  Object.defineProperty(document.documentElement, "mozRequestFullscreen", {
+    configurable: true,
+    value: undefined,
+  });
+  Object.defineProperty(document.documentElement, "msRequestFullscreen", {
     configurable: true,
     value: undefined,
   });

--- a/src/Components/FullscreenButton.tsx
+++ b/src/Components/FullscreenButton.tsx
@@ -8,31 +8,19 @@ const isFullscreenSupported = (): boolean => {
     return false;
   }
 
-  const fullscreenDocument = document as Document & {
-    webkitFullscreenEnabled?: boolean;
-    mozFullScreenEnabled?: boolean;
-    msFullscreenEnabled?: boolean;
-  };
   const fullscreenElement = document.documentElement as HTMLElement & {
     webkitRequestFullscreen?: () => Promise<void>;
-    mozRequestFullScreen?: () => Promise<void>;
+    mozRequestFullscreen?: () => Promise<void>;
     msRequestFullscreen?: () => Promise<void>;
   };
 
-  const canRequestFullscreen = Boolean(
-    fullscreenElement.requestFullscreen ||
-      fullscreenElement.webkitRequestFullscreen ||
-      fullscreenElement.mozRequestFullScreen ||
-      fullscreenElement.msRequestFullscreen
+  // Mobile browsers can report fullscreenEnabled=false while still exposing a working request API.
+  return Boolean(
+    typeof fullscreenElement.requestFullscreen === "function" ||
+      typeof fullscreenElement.webkitRequestFullscreen === "function" ||
+      typeof fullscreenElement.mozRequestFullscreen === "function" ||
+      typeof fullscreenElement.msRequestFullscreen === "function"
   );
-  const fullscreenEnabled =
-    document.fullscreenEnabled ??
-    fullscreenDocument.webkitFullscreenEnabled ??
-    fullscreenDocument.mozFullScreenEnabled ??
-    fullscreenDocument.msFullscreenEnabled;
-
-  // Some browsers expose the request API but omit the enabled flag entirely.
-  return canRequestFullscreen && fullscreenEnabled !== false;
 };
 
 export default function FullscreenButton() {

--- a/src/Components/FullscreenButton.tsx
+++ b/src/Components/FullscreenButton.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useFullscreen } from "@mantine/hooks";
 import { ActionIcon, Tooltip } from "@mantine/core";
-import { IconArrowsMaximize, IconArrowsMinimize, IconArrowsDiagonalMinimize2 } from "@tabler/icons-react";
+import { IconArrowsMaximize, IconArrowsMinimize } from "@tabler/icons-react";
 
 const isFullscreenSupported = (): boolean => {
   if (typeof document === "undefined") {
@@ -40,12 +40,13 @@ export default function FullscreenButton() {
   const [toggleFailed, setToggleFailed] = useState(false);
   const supported = isFullscreenSupported();
 
-  const buttonColor = !supported ? "gray" : toggleFailed ? "orange" : fullscreen ? "red" : "blue";
-  const title = !supported
-    ? "Fullscreen is not supported on this device/browser"
-    : toggleFailed
-    ? "Fullscreen request failed on this browser/device"
-    : "Toggle Fullscreen";
+  // Hide the control on browsers like iPhone Safari that cannot fullscreen arbitrary elements.
+  if (!supported) {
+    return null;
+  }
+
+  const buttonColor = toggleFailed ? "orange" : fullscreen ? "red" : "blue";
+  const title = toggleFailed ? "Fullscreen request failed on this browser/device" : "Toggle Fullscreen";
 
   const handleToggle = async () => {
     try {
@@ -62,17 +63,12 @@ export default function FullscreenButton() {
         variant="outline"
         color={buttonColor}
         onClick={() => {
-          if (supported) {
-            void handleToggle();
-          }
+          void handleToggle();
         }}
         title={title}
-        disabled={!supported}
         aria-label={title}
       >
-        {!supported ? (
-          <IconArrowsDiagonalMinimize2 style={{ width: 18, height: 18 }} />
-        ) : fullscreen ? (
+        {fullscreen ? (
           <IconArrowsMinimize style={{ width: 18, height: 18 }} />
         ) : (
           <IconArrowsMaximize style={{ width: 18, height: 18 }} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Hide the fullscreen button on unsupported browsers to prevent a misleading disabled state.

Previously, the fullscreen button would appear disabled on browsers that do not support the fullscreen API for arbitrary elements (common on mobile). This change hides the button entirely in such cases, providing a clearer user experience.

---
<p><a href="https://cursor.com/agents/bc-467a585e-4d70-4308-827a-b56e4ead572b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-467a585e-4d70-4308-827a-b56e4ead572b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->