### PR TITLE
Keep fullscreen button visible on mobile

### DIFF
--- a/src/Components/FullscreenButton.test.tsx
+++ b/src/Components/FullscreenButton.test.tsx
@@ -109,7 +109,14 @@ test("renders fullscreen button when only webkitRequestFullscreen exists", () =>
   expect(toggle).toHaveBeenCalledTimes(1);
 });
 
-test("does not render fullscreen button when request API is unavailable", () => {
+test("shows unavailable state when request API is unavailable", () => {
+  const toggle = jest.fn();
+  mockedUseFullscreen.mockReturnValue({
+    ref: jest.fn(),
+    toggle,
+    fullscreen: false,
+  });
+
   Object.defineProperty(document.documentElement, "requestFullscreen", {
     configurable: true,
     value: undefined,
@@ -129,7 +136,12 @@ test("does not render fullscreen button when request API is unavailable", () => 
 
   renderButton();
 
-  expect(screen.queryByLabelText("Toggle Fullscreen")).not.toBeInTheDocument();
+  fireEvent.click(screen.getByLabelText("Toggle Fullscreen"));
+
+  expect(
+    screen.getByLabelText("Fullscreen is unavailable in this browser/device context")
+  ).toBeInTheDocument();
+  expect(toggle).not.toHaveBeenCalled();
 });
 
 test("shows failure state when fullscreen request throws", async () => {

--- a/src/Components/FullscreenButton.tsx
+++ b/src/Components/FullscreenButton.tsx
@@ -3,7 +3,7 @@ import { useFullscreen } from "@mantine/hooks";
 import { ActionIcon, Tooltip } from "@mantine/core";
 import { IconArrowsMaximize, IconArrowsMinimize } from "@tabler/icons-react";
 
-const isFullscreenSupported = (): boolean => {
+const hasFullscreenRequestApi = (): boolean => {
   if (typeof document === "undefined") {
     return false;
   }
@@ -25,23 +25,26 @@ const isFullscreenSupported = (): boolean => {
 
 export default function FullscreenButton() {
   const { toggle, fullscreen } = useFullscreen();
-  const [toggleFailed, setToggleFailed] = useState(false);
-  const supported = isFullscreenSupported();
-
-  // Hide the control on browsers like iPhone Safari that cannot fullscreen arbitrary elements.
-  if (!supported) {
-    return null;
-  }
-
-  const buttonColor = toggleFailed ? "orange" : fullscreen ? "red" : "blue";
-  const title = toggleFailed ? "Fullscreen request failed on this browser/device" : "Toggle Fullscreen";
+  const [status, setStatus] = useState<"idle" | "unavailable" | "failed">("idle");
+  const buttonColor = status === "idle" ? (fullscreen ? "red" : "blue") : "orange";
+  const title =
+    status === "unavailable"
+      ? "Fullscreen is unavailable in this browser/device context"
+      : status === "failed"
+      ? "Fullscreen request failed on this browser/device"
+      : "Toggle Fullscreen";
 
   const handleToggle = async () => {
+    if (!hasFullscreenRequestApi()) {
+      setStatus("unavailable");
+      return;
+    }
+
     try {
       await toggle();
-      setToggleFailed(false);
+      setStatus("idle");
     } catch {
-      setToggleFailed(true);
+      setStatus("failed");
     }
   };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to the fullscreen toggle control; main risk is minor UX/regression around status messaging and when `toggle()` is invoked on unsupported browsers.
> 
> **Overview**
> Keeps the fullscreen button visible even when the browser/device can’t enter fullscreen, and adds explicit **status handling** for *unavailable* vs *request failed* cases.
> 
> `FullscreenButton` now checks for a fullscreen request API on click, sets an "unavailable" state instead of returning `null`, and updates tooltip/aria-label text plus button color based on `idle`/`unavailable`/`failed`. Tests were updated to assert the new unavailable-state behavior and ensure `toggle()` is not called when the API is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e759e3f1c635cef87306f5d27f2f82623e8b1ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->