### PR TITLE
Iphone full screen toggle

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -41,5 +41,7 @@ test("maps /skills/C to C# skill data", () => {
 test("renders skills whose route params include encoded slashes", () => {
   renderAtRoute("/skills/Incident%20Response%20%2F%20L1%20On-call");
 
-  expect(screen.getByText("Incident Response / L1 On-call")).toBeInTheDocument();
+  expect(
+    screen.getByRole("heading", { name: "Incident Response / L1 On-call" })
+  ).toBeInTheDocument();
 });

--- a/src/Components/FullscreenButton.test.tsx
+++ b/src/Components/FullscreenButton.test.tsx
@@ -1,31 +1,32 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { MantineProvider } from "@mantine/core";
-import { useFullscreen } from "@mantine/hooks";
 import FullscreenButton from "./FullscreenButton";
 
-jest.mock("@mantine/hooks", () => ({
-  ...jest.requireActual("@mantine/hooks"),
-  useFullscreen: jest.fn(),
-}));
+type FullscreenDocument = Document & {
+  webkitExitFullscreen?: () => Promise<void> | void;
+  msExitFullscreen?: () => Promise<void> | void;
+  mozCancelFullScreen?: () => Promise<void> | void;
+  webkitFullscreenElement?: Element | null;
+  msFullscreenElement?: Element | null;
+  mozFullScreenElement?: Element | null;
+};
 
-const mockedUseFullscreen = useFullscreen as jest.MockedFunction<typeof useFullscreen>;
+type FullscreenElement = HTMLElement & {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+  mozRequestFullscreen?: () => Promise<void> | void;
+  msRequestFullscreen?: () => Promise<void> | void;
+};
 
-beforeEach(() => {
-  Object.defineProperty(document.documentElement, "requestFullscreen", {
+const fullscreenDocument = document as FullscreenDocument;
+const fullscreenElement = document.documentElement as FullscreenElement;
+
+const defineProperty = <T,>(target: object, key: string, value: T) => {
+  Object.defineProperty(target, key, {
     configurable: true,
-    value: jest.fn(),
+    writable: true,
+    value,
   });
-  Object.defineProperty(document, "fullscreenEnabled", {
-    configurable: true,
-    value: undefined,
-  });
-
-  mockedUseFullscreen.mockReturnValue({
-    ref: jest.fn(),
-    toggle: jest.fn(),
-    fullscreen: false,
-  });
-});
+};
 
 const renderButton = () =>
   render(
@@ -34,132 +35,136 @@ const renderButton = () =>
     </MantineProvider>
   );
 
-test("renders fullscreen button when requestFullscreen exists even if fullscreenEnabled is false", () => {
-  const toggle = jest.fn();
-  mockedUseFullscreen.mockReturnValue({
-    ref: jest.fn(),
-    toggle,
-    fullscreen: false,
+const clickButton = async (label: string) => {
+  const button = screen.getByLabelText(label);
+
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   });
+};
 
-  Object.defineProperty(document, "fullscreenEnabled", {
-    configurable: true,
-    value: false,
+const dispatchFullscreenChange = () => {
+  act(() => {
+    document.dispatchEvent(new Event("fullscreenchange"));
   });
+};
 
-  renderButton();
-
-  fireEvent.click(screen.getByLabelText("Toggle Fullscreen"));
-  expect(toggle).toHaveBeenCalledTimes(1);
+beforeEach(() => {
+  defineProperty(document, "fullscreenElement", null);
+  defineProperty(fullscreenDocument, "webkitFullscreenElement", null);
+  defineProperty(fullscreenDocument, "msFullscreenElement", null);
+  defineProperty(fullscreenDocument, "mozFullScreenElement", null);
+  defineProperty(document, "exitFullscreen", jest.fn().mockResolvedValue(undefined));
+  defineProperty(fullscreenDocument, "webkitExitFullscreen", undefined);
+  defineProperty(fullscreenDocument, "msExitFullscreen", undefined);
+  defineProperty(fullscreenDocument, "mozCancelFullScreen", undefined);
+  defineProperty(fullscreenElement, "requestFullscreen", jest.fn().mockResolvedValue(undefined));
+  defineProperty(fullscreenElement, "webkitRequestFullscreen", undefined);
+  defineProperty(fullscreenElement, "mozRequestFullscreen", undefined);
+  defineProperty(fullscreenElement, "msRequestFullscreen", undefined);
 });
 
-test("calls toggle when fullscreen is supported", () => {
-  const toggle = jest.fn();
-  mockedUseFullscreen.mockReturnValue({
-    ref: jest.fn(),
-    toggle,
-    fullscreen: false,
-  });
-
-  Object.defineProperty(document, "fullscreenEnabled", {
-    configurable: true,
-    value: true,
-  });
+test("enters fullscreen with the standard API", async () => {
+  const requestFullscreen = jest.fn().mockResolvedValue(undefined);
+  defineProperty(fullscreenElement, "requestFullscreen", requestFullscreen);
 
   renderButton();
 
-  fireEvent.click(screen.getByLabelText("Toggle Fullscreen"));
-  expect(toggle).toHaveBeenCalledTimes(1);
+  await clickButton("Enter fullscreen");
+
+  await waitFor(() => {
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  expect(screen.getByLabelText("Exit fullscreen")).toBeInTheDocument();
 });
 
-test("treats requestFullscreen as supported when fullscreenEnabled is unavailable", () => {
-  const toggle = jest.fn();
-  mockedUseFullscreen.mockReturnValue({
-    ref: jest.fn(),
-    toggle,
-    fullscreen: false,
-  });
+test("exits fullscreen on the second tap even if no fullscreenchange event arrives", async () => {
+  const requestFullscreen = jest.fn().mockResolvedValue(undefined);
+  const exitFullscreen = jest.fn().mockResolvedValue(undefined);
+
+  defineProperty(fullscreenElement, "requestFullscreen", requestFullscreen);
+  defineProperty(document, "exitFullscreen", exitFullscreen);
 
   renderButton();
 
-  fireEvent.click(screen.getByLabelText("Toggle Fullscreen"));
-  expect(toggle).toHaveBeenCalledTimes(1);
+  await clickButton("Enter fullscreen");
+
+  await waitFor(() => {
+    expect(screen.getByLabelText("Exit fullscreen")).toBeInTheDocument();
+  });
+
+  await clickButton("Exit fullscreen");
+
+  await waitFor(() => {
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  expect(screen.getByLabelText("Enter fullscreen")).toBeInTheDocument();
 });
 
-test("renders fullscreen button when only webkitRequestFullscreen exists", () => {
-  const toggle = jest.fn();
-  mockedUseFullscreen.mockReturnValue({
-    ref: jest.fn(),
-    toggle,
-    fullscreen: false,
-  });
+test("uses webkit exit APIs when mobile Safari reports prefixed fullscreen state", async () => {
+  const webkitExitFullscreen = jest.fn().mockResolvedValue(undefined);
 
-  Object.defineProperty(document.documentElement, "requestFullscreen", {
-    configurable: true,
-    value: undefined,
-  });
-  Object.defineProperty(document.documentElement, "webkitRequestFullscreen", {
-    configurable: true,
-    value: jest.fn(),
-  });
+  defineProperty(document, "fullscreenElement", null);
+  defineProperty(fullscreenDocument, "webkitFullscreenElement", document.documentElement);
+  defineProperty(document, "exitFullscreen", undefined);
+  defineProperty(fullscreenDocument, "webkitExitFullscreen", webkitExitFullscreen);
 
   renderButton();
 
-  fireEvent.click(screen.getByLabelText("Toggle Fullscreen"));
-  expect(toggle).toHaveBeenCalledTimes(1);
+  await clickButton("Exit fullscreen");
+
+  await waitFor(() => {
+    expect(webkitExitFullscreen).toHaveBeenCalledTimes(1);
+  });
 });
 
-test("shows unavailable state when request API is unavailable", () => {
-  const toggle = jest.fn();
-  mockedUseFullscreen.mockReturnValue({
-    ref: jest.fn(),
-    toggle,
-    fullscreen: false,
+test("syncs the button state from document fullscreenchange events", async () => {
+  renderButton();
+
+  defineProperty(document, "fullscreenElement", document.documentElement);
+  dispatchFullscreenChange();
+
+  await waitFor(() => {
+    expect(screen.getByLabelText("Exit fullscreen")).toBeInTheDocument();
   });
 
-  Object.defineProperty(document.documentElement, "requestFullscreen", {
-    configurable: true,
-    value: undefined,
+  defineProperty(document, "fullscreenElement", null);
+  dispatchFullscreenChange();
+
+  await waitFor(() => {
+    expect(screen.getByLabelText("Enter fullscreen")).toBeInTheDocument();
   });
-  Object.defineProperty(document.documentElement, "webkitRequestFullscreen", {
-    configurable: true,
-    value: undefined,
-  });
-  Object.defineProperty(document.documentElement, "mozRequestFullscreen", {
-    configurable: true,
-    value: undefined,
-  });
-  Object.defineProperty(document.documentElement, "msRequestFullscreen", {
-    configurable: true,
-    value: undefined,
-  });
+});
+
+test("shows unavailable state when request API is unavailable", async () => {
+  defineProperty(fullscreenElement, "requestFullscreen", undefined);
+  defineProperty(fullscreenElement, "webkitRequestFullscreen", undefined);
+  defineProperty(fullscreenElement, "mozRequestFullscreen", undefined);
+  defineProperty(fullscreenElement, "msRequestFullscreen", undefined);
 
   renderButton();
 
-  fireEvent.click(screen.getByLabelText("Toggle Fullscreen"));
+  await clickButton("Enter fullscreen");
 
-  expect(
-    screen.getByLabelText("Fullscreen is unavailable in this browser/device context")
-  ).toBeInTheDocument();
-  expect(toggle).not.toHaveBeenCalled();
+  await waitFor(() => {
+    expect(
+      screen.getByLabelText("Fullscreen is unavailable in this browser/device context")
+    ).toBeInTheDocument();
+  });
 });
 
 test("shows failure state when fullscreen request throws", async () => {
-  const toggle = jest.fn().mockRejectedValue(new Error("fullscreen failed"));
-  mockedUseFullscreen.mockReturnValue({
-    ref: jest.fn(),
-    toggle,
-    fullscreen: false,
-  });
-
-  Object.defineProperty(document, "fullscreenEnabled", {
-    configurable: true,
-    value: true,
-  });
+  defineProperty(
+    fullscreenElement,
+    "requestFullscreen",
+    jest.fn().mockRejectedValue(new Error("fullscreen failed"))
+  );
 
   renderButton();
 
-  fireEvent.click(screen.getByLabelText("Toggle Fullscreen"));
+  await clickButton("Enter fullscreen");
 
   await waitFor(() => {
     expect(

--- a/src/Components/FullscreenButton.tsx
+++ b/src/Components/FullscreenButton.tsx
@@ -1,18 +1,54 @@
-import { useState } from "react";
-import { useFullscreen } from "@mantine/hooks";
+import { useEffect, useState } from "react";
 import { ActionIcon, Tooltip } from "@mantine/core";
 import { IconArrowsMaximize, IconArrowsMinimize } from "@tabler/icons-react";
 
-const hasFullscreenRequestApi = (): boolean => {
+type FullscreenDocument = Document & {
+  webkitExitFullscreen?: () => Promise<void> | void;
+  msExitFullscreen?: () => Promise<void> | void;
+  mozCancelFullScreen?: () => Promise<void> | void;
+  webkitFullscreenElement?: Element | null;
+  msFullscreenElement?: Element | null;
+  mozFullScreenElement?: Element | null;
+};
+
+type FullscreenElement = HTMLElement & {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+  mozRequestFullscreen?: () => Promise<void> | void;
+  msRequestFullscreen?: () => Promise<void> | void;
+};
+
+const getFullscreenDocument = (): FullscreenDocument | null => {
   if (typeof document === "undefined") {
+    return null;
+  }
+
+  return document as FullscreenDocument;
+};
+
+const getFullscreenElement = (): Element | null => {
+  const fullscreenDocument = getFullscreenDocument();
+
+  if (!fullscreenDocument) {
+    return null;
+  }
+
+  return (
+    fullscreenDocument.fullscreenElement ??
+    fullscreenDocument.webkitFullscreenElement ??
+    fullscreenDocument.msFullscreenElement ??
+    fullscreenDocument.mozFullScreenElement ??
+    null
+  );
+};
+
+const hasFullscreenRequestApi = (): boolean => {
+  const fullscreenDocument = getFullscreenDocument();
+
+  if (!fullscreenDocument) {
     return false;
   }
 
-  const fullscreenElement = document.documentElement as HTMLElement & {
-    webkitRequestFullscreen?: () => Promise<void>;
-    mozRequestFullscreen?: () => Promise<void>;
-    msRequestFullscreen?: () => Promise<void>;
-  };
+  const fullscreenElement = fullscreenDocument.documentElement as FullscreenElement;
 
   // Mobile browsers can report fullscreenEnabled=false while still exposing a working request API.
   return Boolean(
@@ -23,16 +59,110 @@ const hasFullscreenRequestApi = (): boolean => {
   );
 };
 
+const requestFullscreen = async (): Promise<void> => {
+  const fullscreenDocument = getFullscreenDocument();
+
+  if (!fullscreenDocument) {
+    throw new Error("Fullscreen is unavailable");
+  }
+
+  const fullscreenElement = fullscreenDocument.documentElement as FullscreenElement;
+
+  if (typeof fullscreenElement.requestFullscreen === "function") {
+    await fullscreenElement.requestFullscreen();
+    return;
+  }
+
+  if (typeof fullscreenElement.webkitRequestFullscreen === "function") {
+    await fullscreenElement.webkitRequestFullscreen();
+    return;
+  }
+
+  if (typeof fullscreenElement.mozRequestFullscreen === "function") {
+    await fullscreenElement.mozRequestFullscreen();
+    return;
+  }
+
+  if (typeof fullscreenElement.msRequestFullscreen === "function") {
+    await fullscreenElement.msRequestFullscreen();
+    return;
+  }
+
+  throw new Error("Fullscreen is unavailable");
+};
+
+const exitFullscreen = async (): Promise<void> => {
+  const fullscreenDocument = getFullscreenDocument();
+
+  if (!fullscreenDocument) {
+    throw new Error("Fullscreen is unavailable");
+  }
+
+  if (typeof fullscreenDocument.exitFullscreen === "function") {
+    await fullscreenDocument.exitFullscreen();
+    return;
+  }
+
+  if (typeof fullscreenDocument.webkitExitFullscreen === "function") {
+    await fullscreenDocument.webkitExitFullscreen();
+    return;
+  }
+
+  if (typeof fullscreenDocument.msExitFullscreen === "function") {
+    await fullscreenDocument.msExitFullscreen();
+    return;
+  }
+
+  if (typeof fullscreenDocument.mozCancelFullScreen === "function") {
+    await fullscreenDocument.mozCancelFullScreen();
+    return;
+  }
+
+  throw new Error("Fullscreen is unavailable");
+};
+
 export default function FullscreenButton() {
-  const { toggle, fullscreen } = useFullscreen();
+  const [isFullscreen, setIsFullscreen] = useState(() => Boolean(getFullscreenElement()));
   const [status, setStatus] = useState<"idle" | "unavailable" | "failed">("idle");
-  const buttonColor = status === "idle" ? (fullscreen ? "red" : "blue") : "orange";
+
+  useEffect(() => {
+    const fullscreenDocument = getFullscreenDocument();
+
+    if (!fullscreenDocument) {
+      return undefined;
+    }
+
+    const syncFullscreenState = () => {
+      setIsFullscreen(Boolean(getFullscreenElement()));
+    };
+
+    const events = [
+      "fullscreenchange",
+      "webkitfullscreenchange",
+      "mozfullscreenchange",
+      "MSFullscreenChange",
+    ] as const;
+
+    events.forEach((eventName) => {
+      fullscreenDocument.addEventListener(eventName, syncFullscreenState);
+    });
+
+    return () => {
+      events.forEach((eventName) => {
+        fullscreenDocument.removeEventListener(eventName, syncFullscreenState);
+      });
+    };
+  }, []);
+
+  const buttonColor = status === "idle" ? (isFullscreen ? "red" : "blue") : "orange";
   const title =
     status === "unavailable"
       ? "Fullscreen is unavailable in this browser/device context"
       : status === "failed"
       ? "Fullscreen request failed on this browser/device"
-      : "Toggle Fullscreen";
+      : isFullscreen
+      ? "Exit fullscreen"
+      : "Enter fullscreen";
 
   const handleToggle = async () => {
     if (!hasFullscreenRequestApi()) {
@@ -41,7 +171,17 @@ export default function FullscreenButton() {
     }
 
     try {
-      await toggle();
+      const currentlyFullscreen = isFullscreen || Boolean(getFullscreenElement());
+
+      if (currentlyFullscreen) {
+        await exitFullscreen();
+        setIsFullscreen(false);
+      } else {
+        await requestFullscreen();
+        // iPhone/Safari can lag on fullscreenchange, so keep local state in sync with the last action.
+        setIsFullscreen(true);
+      }
+
       setStatus("idle");
     } catch {
       setStatus("failed");
@@ -59,7 +199,7 @@ export default function FullscreenButton() {
         title={title}
         aria-label={title}
       >
-        {fullscreen ? (
+        {isFullscreen ? (
           <IconArrowsMinimize style={{ width: 18, height: 18 }} />
         ) : (
           <IconArrowsMaximize style={{ width: 18, height: 18 }} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes mobile fullscreen toggle by replacing Mantine hook with native browser API and updating tests.

The previous `useFullscreen` hook was too optimistic for Safari-style fullscreen events, leading to the button getting stuck in the wrong state on mobile devices like the iPhone 17 Pro Max. This change ensures the component's state accurately reflects the browser's fullscreen status.

---
<p><a href="https://cursor.com/agents/bc-c7cb331e-ab27-48ed-97e6-bef1eb000a71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7cb331e-ab27-48ed-97e6-bef1eb000a71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->