### PR TITLE
Default SPA theme to the user's system preference

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,23 @@ import {
 import { useHotkeys, useLocalStorage } from "@mantine/hooks";
 import RoutingContainer from "./RoutingContainer";
 
+const getPreferredColorScheme = (): ColorScheme => {
+  if (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  ) {
+    return "dark";
+  }
+
+  return "light";
+};
+
 function App() {
   const [colorScheme, setColorScheme] = useLocalStorage<ColorScheme>({
     key: "mantine-color-scheme",
-    defaultValue: "light",
-    getInitialValueInEffect: true,
+    defaultValue: getPreferredColorScheme(),
+    getInitialValueInEffect: false,
   });
 
   const toggleColorScheme = (value?: ColorScheme) =>

--- a/src/AppTheme.test.tsx
+++ b/src/AppTheme.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import App from "./App";
+
+jest.mock("./RoutingContainer", () => {
+  const React = require("react");
+  const { useMantineColorScheme } = require("@mantine/core");
+
+  return function RoutingContainerMock() {
+    const { colorScheme } = useMantineColorScheme();
+
+    return <div data-testid="color-scheme">{colorScheme}</div>;
+  };
+});
+
+const setMatchMedia = (matches: boolean) => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+};
+
+describe("App theme defaults", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test("defaults to dark when the OS preference is dark", () => {
+    setMatchMedia(true);
+
+    render(<App />);
+
+    expect(screen.getByTestId("color-scheme")).toHaveTextContent("dark");
+  });
+
+  test("defaults to light when the OS preference is light", () => {
+    setMatchMedia(false);
+
+    render(<App />);
+
+    expect(screen.getByTestId("color-scheme")).toHaveTextContent("light");
+  });
+
+  test("keeps a stored user preference over the OS preference", () => {
+    setMatchMedia(true);
+    window.localStorage.setItem("mantine-color-scheme", JSON.stringify("light"));
+
+    render(<App />);
+
+    expect(screen.getByTestId("color-scheme")).toHaveTextContent("light");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- read `prefers-color-scheme` on first load instead of hardcoding a light default
- keep persisted `mantine-color-scheme` values taking precedence over the system default
- add focused tests covering dark, light, and stored-preference startup behavior
- merge the latest `master` into this branch before deployment

## Testing
- CI=true npx react-scripts test --watchAll=false --runInBand --runTestsByPath src/AppTheme.test.tsx src/App.test.tsx
- npm run build
- manually verified in Chrome by clearing `mantine-color-scheme` in localStorage under emulated light and dark `prefers-color-scheme` settings
- npm run deploy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72843ab8-75cb-425e-8b58-55323193ad77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72843ab8-75cb-425e-8b58-55323193ad77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

