### PR TITLE
Align published site domain with GitHub Pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-huntertcarver.com

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ App runs at `http://localhost:3000`.
 
 ## Deployment
 
-This project uses `gh-pages` and `homepage` in `package.json`.
+This project uses `gh-pages`, a `public/CNAME` file, and the `homepage` value in `package.json`.
+
+The published production site is `https://huntertcarver.com`.
 
 Deploy with:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "my-app",
   "version": "0.1.0",
-  "homepage": "https://huntertcarver.me",
+  "homepage": "https://huntertcarver.com",
   "private": true,
   "dependencies": {
     "@mantine/carousel": "^5.6.1",

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+huntertcarver.com


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- align the CRA `homepage` with the active GitHub Pages custom domain `huntertcarver.com`
- move the `CNAME` file into `public/` so every deploy artifact preserves the custom domain mapping
- document the canonical production URL in the README

## Root cause
The repository still referenced `huntertcarver.me`, but GitHub Pages is configured to publish `huntertcarver.com`. The `.com` domain is live and resolves over IPv4/IPv6, while `.me` is not resolving in runtime checks.

## Testing
- `npm run build`
- `npm run check`
- `gh api repos/huntertcarver/Hunters-SPA/pages`
- `curl -I -L http://huntertcarver.com`
- `curl -I https://huntertcarver.me/static/js/main.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b189f417-9e66-4569-be77-b076e82a9cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b189f417-9e66-4569-be77-b076e82a9cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

